### PR TITLE
Fix header parsing

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -80,7 +80,8 @@ import io.thp.pyotherside 1.3
               onReleased: {
                 content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
                 python.call('gemini.main', [adress.text], function(returnValue) {
-                    content.text = returnValue;
+                    console.assert(returnValue.status === 'success', returnValue.message);
+                    content.text = returnValue.content;
                 })
                 python.call('gemini.history', [adress.text], function(returnValue) {
                     console.log("");
@@ -118,7 +119,8 @@ import io.thp.pyotherside 1.3
                 python.call('gemini.back', [], function(returnValue) {
                     adress.text = returnValue;
                     python.call('gemini.main', [adress.text], function(returnValue) {
-                        content.text = returnValue;
+                        console.assert(returnValue.status === 'success', returnValue.message);
+                        content.text = returnValue.content;
                     })
                 })
                 back.scale = 1

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -144,14 +144,12 @@ import io.thp.pyotherside 1.3
           wrapMode: Text.WordWrap
           onLinkActivated: {
             content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-            python.call('gemini.history', [link], function(returnValue) {
-                console.log("");
-            })
-            python.call('gemini.where_am_I', ["forward"], function(returnValue) {
-                console.log("");
-            })
+            python.call('gemini.history', [link], function(returnValue) {})
+            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
             python.call('gemini.main', [link], function(returnValue) {
-                content.text = returnValue;
+                console.assert(returnValue.status === 'success', returnValue.message);
+
+                content.text = returnValue.content;
                 adress.text = link
             })
           }
@@ -169,14 +167,12 @@ import io.thp.pyotherside 1.3
             importModule('gemini', function() {
                 console.log('module imported');
                 python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-                    content.text = returnValue;
+                    console.assert(returnValue.status === 'success', returnValue.message);
+
+                    content.text = returnValue.content;
                 })
-                python.call('gemini.where_am_I', ['forward'], function(returnValue) {
-                    console.log("");
-                })
-                python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-                    console.log("");
-                })
+                python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
+                python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
             });
         }
 

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -40,7 +40,7 @@ def get_site(url):
         fp = s.makefile("rb")
         header = fp.readline()
         header = header.decode("UTF-8").strip()
-        status, mime = header.split()
+        status, mime = header.split()[:2]
         # Handle input requests
         if status.startswith("1"):
             # Prompt

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -185,11 +185,20 @@ def back():
 
 def main(url):
     try:
-        returnValue = instert_html_links(get_site(url),get_links(get_site(url), url))
+        gemsite = get_site(url)
+        returnValue = instert_html_links(gemsite, get_links(gemsite, url))
 #        where_am_I("forward")
 #        history(url)
-        return returnValue
-    except:
+        return {
+            'status': 'success',
+            'content': returnValue
+        }
+    except Exception as e:
 #        where_am_I("forward")
 #        history(url)
-        return "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯"
+        return {
+            'status': 'error',
+            'content': "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯",
+            'message': str(e)
+        }
+        return


### PR DESCRIPTION
Greetings, I found a bug while using your app and was able to find a fix for it!

Some gemini sites/servers will return more header values than just status and mime, when they do it causes an error in `gemini.py:43` The example I have is `gemini://mozz.us` which also returns a language value in the header. Python returns an error because it can't unpack all three elements into the two variables assigned. My solution was to just grab the first two values from the header, which seems to do the trick as long as the header is always ordered the same way (I'm not super familiar with the Gemini spec, it may be required to order them as such).

I also made some changes so that errors will get logged when trying to load a page. I don't have much experience with qml, so what I did may not be the proper way to go about it. But it worked. If you want I can remove that part of the pull request.

Thanks!