### PR TITLE
Updated page header

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -21,100 +21,21 @@ import QtQuick.Layouts 1.3
 import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 
- Rectangle{
-    id: root
-    color: "#515151"
+MainView {
+  Page {
+      id: root
 
-    width: 1080
-    height: 1920
-    Rectangle {
-      id: searchbar
-      color: "grey"
-      z: 1
-      height: root.height / 12
-      anchors.left: parent.left
-      anchors.top: parent.top
-      anchors.right: parent.right
-      radius: 3
-      Rectangle{
-        color: "white"
-        anchors.fill: parent
-        anchors.centerIn: parent
-        anchors.topMargin: 1/5 * parent.height
-        anchors.bottomMargin: 1/5 * parent.height
-        anchors.leftMargin: 1/5 * parent.height
-        anchors.rightMargin: 1/5 * parent.height
-        radius: 15
-        TextInput{
-          id: adress
-          anchors.fill: parent
-          anchors.topMargin: parent.height / 3
-          anchors.leftMargin: 1/5 * parent.height
-          anchors.centerIn: parent
-          text: "gemini://gemini.circumlunar.space/servers/"
-
-
-        }
-        Rectangle{
-          id: searchRec
-          width: adress.height
-          height: adress.height
-
-          anchors.right: parent.right
-          anchors.rightMargin: 1/5 * parent.height
-          anchors.verticalCenter: parent.verticalCenter
-
-
-          Image{
-            id: search
-            source: "../assets/search.png"
-            anchors.fill: parent
-            anchors.centerIn: parent
-
-          }
-          MouseArea {
-              anchors.fill: parent
-              onPressed: {
-                search.scale = 0.8
-              }
-              onReleased: {
-                content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-                python.call('gemini.main', [adress.text], function(returnValue) {
-                    console.assert(returnValue.status === 'success', returnValue.message);
-                    content.text = returnValue.content;
-                })
-                python.call('gemini.history', [adress.text], function(returnValue) {
-                    console.log("");
-                })
-                python.call('gemini.where_am_I', ["forward"], function(returnValue) {
-                    console.log("");
-                })
-                search.scale = 1
-              }
-          }
-        }
-        Rectangle{
-          width: adress.height
-          height: adress.height
-
-          anchors.right: searchRec.left
-          anchors.rightMargin: 1/5 * parent.height
-          anchors.verticalCenter: parent.verticalCenter
-
-
-          Image{
-            id: back
-            source: "../assets/arrow.png"
-            anchors.fill: parent
-            anchors.centerIn: parent
-
-          }
-          MouseArea {
-              anchors.fill: parent
-              onPressed: {
-                back.scale = 0.8
-              }
-              onReleased: {
+      header: PageHeader {
+        id: pageHeader
+        flickable: flick
+        exposed: true
+        leadingActionBar {
+          numberOfSlots: 1
+          actions: [
+            Action {
+              id: back
+              iconName: "back"
+              onTriggered: {
                 content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
                 python.call('gemini.back', [], function(returnValue) {
                     adress.text = returnValue;
@@ -123,63 +44,109 @@ import io.thp.pyotherside 1.3
                         content.text = returnValue.content;
                     })
                 })
-                back.scale = 1
               }
+            }
+          ]
+        }
+
+        contents: Rectangle {
+          id: addressWrapper
+          radius: 15
+          color: "#F0F0F0"
+          anchors.fill: parent
+          anchors.topMargin: 15
+          anchors.bottomMargin: 15
+
+          TextInput {
+            id: adress
+            anchors {
+              fill: parent
+              centerIn: parent
+              leftMargin: 10
+              rightMargin: 10
+            }
+            verticalAlignment: Qt.AlignVCenter
+            horizontalAlignment: Qt.AlignLeft
+            text: "gemini://gemini.circumlunar.space/servers/"
+
+            onActiveFocusChanged: {
+              if (activeFocus) {
+                back.visible = false
+              } else {
+                back.visible = true
+              }
+            }
+
+            onAccepted: {
+              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+              python.call('gemini.main', [adress.text], function(returnValue) {
+                  console.assert(returnValue.status === 'success', returnValue.message);
+                  content.text = returnValue.content;
+              })
+              python.call('gemini.history', [adress.text], function(returnValue) {
+                  console.log("");
+              })
+              python.call('gemini.where_am_I', ["forward"], function(returnValue) {
+                  console.log("");
+              })
+            }
           }
         }
       }
-    }
-    Flickable {
-        id: flick
+      
+      Rectangle {
+        id: flickWrapper
+        anchors.fill: parent
+        color: "black"
 
-        anchors.left: parent.left
-        anchors.top: searchbar.bottom
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        contentHeight: content.paintedHeight
-        Text{
-          id: content
-          width: root.width
-          color: "#FFFFFFFF"
-          textFormat : Text.RichText
-          font.pointSize: 35
-          wrapMode: Text.WordWrap
-          onLinkActivated: {
-            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-            python.call('gemini.history', [link], function(returnValue) {})
-            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-            python.call('gemini.main', [link], function(returnValue) {
-                console.assert(returnValue.status === 'success', returnValue.message);
+        Flickable {
+          id: flick
+          anchors.fill: parent
+          contentHeight: content.paintedHeight
 
-                content.text = returnValue.content;
-                adress.text = link
-            })
+          Text{
+            id: content
+            width: root.width
+            color: "#FFFFFFFF"
+            textFormat : Text.RichText
+            font.pointSize: 35
+            wrapMode: Text.WordWrap
+            onLinkActivated: {
+              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+              python.call('gemini.history', [link], function(returnValue) {})
+              python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
+              python.call('gemini.main', [link], function(returnValue) {
+                  console.assert(returnValue.status === 'success', returnValue.message);
+
+                  content.text = returnValue.content;
+                  adress.text = link
+              })
+            }
           }
         }
+      }
 
+      Python {
+          id: python
 
-    }
+          Component.onCompleted: {
+              addImportPath(Qt.resolvedUrl('../src/'));
 
-    Python {
-        id: python
+              importModule('gemini', function() {
+                  console.log('module imported');
+                  python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
+                      console.assert(returnValue.status === 'success', returnValue.message);
 
-        Component.onCompleted: {
-            addImportPath(Qt.resolvedUrl('../src/'));
+                      content.text = returnValue.content;
+                  })
+                  python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
+                  python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
+              });
+          }
 
-            importModule('gemini', function() {
-                console.log('module imported');
-                python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-                    console.assert(returnValue.status === 'success', returnValue.message);
-
-                    content.text = returnValue.content;
-                })
-                python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
-                python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
-            });
-        }
-
-        onError: {
-            console.log('python error: ' + traceback);
-        }
-    }
+          onError: {
+              console.log('python error: ' + traceback);
+          }
+      }
+  }
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -75,7 +75,7 @@ MainView {
             leftMargin: 10
             rightMargin: 10
           }
-          
+
           onActiveFocusChanged: {
             if (activeFocus) {
               back.visible = false
@@ -101,11 +101,17 @@ MainView {
         }
       }
     }
-    
+
     Flickable {
       id: flick
       anchors.fill: parent
       contentHeight: content.paintedHeight
+
+      MouseArea {
+        // This is to remove focus from the address bar when tapping off of it
+        anchors.fill: parent
+        onClicked: forceActiveFocus()
+      }
 
       Text{
         id: content

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -22,6 +22,9 @@ import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 
 MainView {
+  applicationName: "Gem"
+  backgroundColor: "#515151"
+
   Page {
       id: root
 
@@ -94,34 +97,28 @@ MainView {
         }
       }
       
-      Rectangle {
-        id: flickWrapper
+      Flickable {
+        id: flick
         anchors.fill: parent
-        color: "black"
+        contentHeight: content.paintedHeight
 
-        Flickable {
-          id: flick
-          anchors.fill: parent
-          contentHeight: content.paintedHeight
+        Text{
+          id: content
+          width: root.width
+          color: "#FFFFFFFF"
+          textFormat : Text.RichText
+          font.pointSize: 35
+          wrapMode: Text.WordWrap
+          onLinkActivated: {
+            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+            python.call('gemini.history', [link], function(returnValue) {})
+            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
+            python.call('gemini.main', [link], function(returnValue) {
+                console.assert(returnValue.status === 'success', returnValue.message);
 
-          Text{
-            id: content
-            width: root.width
-            color: "#FFFFFFFF"
-            textFormat : Text.RichText
-            font.pointSize: 35
-            wrapMode: Text.WordWrap
-            onLinkActivated: {
-              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-              python.call('gemini.history', [link], function(returnValue) {})
-              python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-              python.call('gemini.main', [link], function(returnValue) {
-                  console.assert(returnValue.status === 'success', returnValue.message);
-
-                  content.text = returnValue.content;
-                  adress.text = link
-              })
-            }
+                content.text = returnValue.content;
+                adress.text = link
+            })
           }
         }
       }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -71,6 +71,7 @@ MainView {
             verticalAlignment: Qt.AlignVCenter
             horizontalAlignment: Qt.AlignLeft
             text: "gemini://gemini.circumlunar.space/servers/"
+            layer.enabled: true
 
             onActiveFocusChanged: {
               if (activeFocus) {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -26,125 +26,133 @@ MainView {
   backgroundColor: "#515151"
 
   Page {
-      id: root
+    id: root
 
-      header: PageHeader {
-        id: pageHeader
-        flickable: flick
-        exposed: true
-        leadingActionBar {
-          numberOfSlots: 1
-          actions: [
-            Action {
-              id: back
-              iconName: "back"
-              onTriggered: {
-                content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-                python.call('gemini.back', [], function(returnValue) {
-                    adress.text = returnValue;
-                    python.call('gemini.main', [adress.text], function(returnValue) {
-                        console.assert(returnValue.status === 'success', returnValue.message);
-                        content.text = returnValue.content;
-                    })
-                })
-              }
-            }
-          ]
-        }
+    header: PageHeader {
+      id: pageHeader
+      flickable: flick
+      exposed: true
 
-        contents: Rectangle {
-          id: addressWrapper
-          radius: 15
-          color: "#F0F0F0"
-          anchors.fill: parent
-          anchors.topMargin: 15
-          anchors.bottomMargin: 15
+      leadingActionBar {
+        numberOfSlots: 1
+        actions: [
+          Action {
+            id: back
+            iconName: "back"
 
-          TextInput {
-            id: adress
-            anchors {
-              fill: parent
-              centerIn: parent
-              leftMargin: 10
-              rightMargin: 10
-            }
-            verticalAlignment: Qt.AlignVCenter
-            horizontalAlignment: Qt.AlignLeft
-            text: "gemini://gemini.circumlunar.space/servers/"
-            layer.enabled: true
-
-            onActiveFocusChanged: {
-              if (activeFocus) {
-                back.visible = false
-              } else {
-                back.visible = true
-              }
-            }
-
-            onAccepted: {
+            onTriggered: {
               content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-              python.call('gemini.main', [adress.text], function(returnValue) {
+
+              python.call('gemini.back', [], function(returnValue) {
+                adress.text = returnValue;
+                python.call('gemini.main', [adress.text], function(returnValue) {
                   console.assert(returnValue.status === 'success', returnValue.message);
                   content.text = returnValue.content;
-              })
-              python.call('gemini.history', [adress.text], function(returnValue) {
-                  console.log("");
-              })
-              python.call('gemini.where_am_I', ["forward"], function(returnValue) {
-                  console.log("");
+                })
               })
             }
           }
-        }
+        ]
       }
-      
-      Flickable {
-        id: flick
+
+      contents: Rectangle {
+        id: addressWrapper
+        radius: 15
+        color: "#F0F0F0"
         anchors.fill: parent
-        contentHeight: content.paintedHeight
+        anchors.topMargin: 15
+        anchors.bottomMargin: 15
 
-        Text{
-          id: content
-          width: root.width
-          color: "#FFFFFFFF"
-          textFormat : Text.RichText
-          font.pointSize: 35
-          wrapMode: Text.WordWrap
-          onLinkActivated: {
+        TextInput {
+          id: adress
+          verticalAlignment: Qt.AlignVCenter
+          horizontalAlignment: Qt.AlignLeft
+          text: "gemini://gemini.circumlunar.space/servers/"
+          layer.enabled: true
+          anchors {
+            fill: parent
+            centerIn: parent
+            leftMargin: 10
+            rightMargin: 10
+          }
+          
+          onActiveFocusChanged: {
+            if (activeFocus) {
+              back.visible = false
+            } else {
+              back.visible = true
+            }
+          }
+
+          onAccepted: {
             content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-            python.call('gemini.history', [link], function(returnValue) {})
-            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-            python.call('gemini.main', [link], function(returnValue) {
-                console.assert(returnValue.status === 'success', returnValue.message);
 
-                content.text = returnValue.content;
-                adress.text = link
+            python.call('gemini.main', [adress.text], function(returnValue) {
+              console.assert(returnValue.status === 'success', returnValue.message);
+              content.text = returnValue.content;
+            })
+            python.call('gemini.history', [adress.text], function(returnValue) {
+              console.log("");
+            })
+            python.call('gemini.where_am_I', ["forward"], function(returnValue) {
+              console.log("");
             })
           }
         }
       }
+    }
+    
+    Flickable {
+      id: flick
+      anchors.fill: parent
+      contentHeight: content.paintedHeight
 
-      Python {
-          id: python
+      Text{
+        id: content
+        width: root.width
+        color: "#FFFFFFFF"
+        textFormat : Text.RichText
+        font.pointSize: 35
+        wrapMode: Text.WordWrap
 
-          Component.onCompleted: {
-              addImportPath(Qt.resolvedUrl('../src/'));
+        onLinkActivated: {
+          content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
 
-              importModule('gemini', function() {
-                  console.log('module imported');
-                  python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-                      console.assert(returnValue.status === 'success', returnValue.message);
+          python.call('gemini.history', [link], function(returnValue) {})
+          python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
+          python.call('gemini.main', [link], function(returnValue) {
+            console.assert(returnValue.status === 'success', returnValue.message);
 
-                      content.text = returnValue.content;
-                  })
-                  python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
-                  python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
-              });
-          }
-
-          onError: {
-              console.log('python error: ' + traceback);
-          }
+            content.text = returnValue.content;
+            adress.text = link
+          })
+        }
       }
+    }
+
+    Python {
+      id: python
+
+      Component.onCompleted: {
+        addImportPath(Qt.resolvedUrl('../src/'));
+
+        importModule('gemini', function() {
+          console.log('module imported');
+
+          python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
+            console.assert(returnValue.status === 'success', returnValue.message);
+
+            content.text = returnValue.content;
+          })
+
+          python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
+          python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {});
+        });
+      }
+
+      onError: {
+        console.log('python error: ' + traceback);
+      }
+    }
   }
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -22,7 +22,7 @@ import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 
 MainView {
-  applicationName: "Gem"
+  applicationName: "gem.aaron"
   backgroundColor: "#515151"
 
   Page {


### PR DESCRIPTION
Hi!

I'm continuing to play around with QML ubuntu touch applications and learning how they work. In that process I discovered the PageHeader component from Ubuntu.Components and tried implementing it in Gem. I ended up kinda refactoring the QML structure quite a bit.

With the PageHeader component I also implemented loading an address when you hit enter on the keyboard (so you don't need a specific 'search' button). I also made it so that tapping outside of the address bar (when the keyboard is active) will make the address bar lose focus.

This is a fairly big, unrequested change so I understand if you don't want to merge it or want me to make changes. If you are not open to these kinds of changes just let me know and I'll keep them to myself :) (I have another branch in my repo for forward navigation).

Thanks!