### PR TITLE
Bugfix/invalid protocols

### DIFF
--- a/src/gemini.py
+++ b/src/gemini.py
@@ -14,6 +14,7 @@ import textwrap
 import urllib.parse
 import pyotherside
 import pickle
+import re
 
 storage_dir = "/home/phablet/.local/share/gem.aaron"
 
@@ -66,9 +67,9 @@ class Gemini:
         # Absolutise relative links
         if "://" not in relative:
             # Python's URL tools somehow only work with known schemes?
-            base = base.replace("gemini://","http://")
+            base = re.sub("gemini://", "http://", base, flags=re.IGNORECASE)
             relative = urllib.parse.urljoin(base, relative)
-            relative = relative.replace("http://", "gemini://")
+            relative = re.sub("http://", "gemini://", relative, flags=re.IGNORECASE)
         return relative
 
     def get_site(self, url):

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -180,7 +180,12 @@ class Gemini:
 
         return self.load(url)
 
-    def goto(self, url):
+    def goto(self, _url):
+        if "://" not in _url:
+            url = "gemini://" + _url
+        else:
+            url = _url
+
         if url.split(':')[0] in ["https", "http:"]:
             return pyotherside.send('externalUrl', url)
 


### PR DESCRIPTION
The first issue is that if you type a url in to the address bar without specifying the protocol it would fail, this change will automatically add `gemini://` to the url before fetching the page.
The second issue is that if you are on a page where the protocol in the url starts with a capital letter then clicking on a relative link in the page would fail (there was some substitution done with a lowercase string).