### PR TITLE
Feature/page caching

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -21,100 +21,21 @@ import QtQuick.Layouts 1.3
 import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 
- Rectangle{
-    id: root
-    color: "#515151"
+MainView {
+  Page {
+      id: root
 
-    width: 1080
-    height: 1920
-    Rectangle {
-      id: searchbar
-      color: "grey"
-      z: 1
-      height: root.height / 12
-      anchors.left: parent.left
-      anchors.top: parent.top
-      anchors.right: parent.right
-      radius: 3
-      Rectangle{
-        color: "white"
-        anchors.fill: parent
-        anchors.centerIn: parent
-        anchors.topMargin: 1/5 * parent.height
-        anchors.bottomMargin: 1/5 * parent.height
-        anchors.leftMargin: 1/5 * parent.height
-        anchors.rightMargin: 1/5 * parent.height
-        radius: 15
-        TextInput{
-          id: adress
-          anchors.fill: parent
-          anchors.topMargin: parent.height / 3
-          anchors.leftMargin: 1/5 * parent.height
-          anchors.centerIn: parent
-          text: "gemini://gemini.circumlunar.space/servers/"
-
-
-        }
-        Rectangle{
-          id: searchRec
-          width: adress.height
-          height: adress.height
-
-          anchors.right: parent.right
-          anchors.rightMargin: 1/5 * parent.height
-          anchors.verticalCenter: parent.verticalCenter
-
-
-          Image{
-            id: search
-            source: "../assets/search.png"
-            anchors.fill: parent
-            anchors.centerIn: parent
-
-          }
-          MouseArea {
-              anchors.fill: parent
-              onPressed: {
-                search.scale = 0.8
-              }
-              onReleased: {
-                content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-                python.call('gemini.main', [adress.text], function(returnValue) {
-                    console.assert(returnValue.status === 'success', returnValue.message);
-                    content.text = returnValue.content;
-                })
-                python.call('gemini.history', [adress.text], function(returnValue) {
-                    console.log("");
-                })
-                python.call('gemini.where_am_I', ["forward"], function(returnValue) {
-                    console.log("");
-                })
-                search.scale = 1
-              }
-          }
-        }
-        Rectangle{
-          width: adress.height
-          height: adress.height
-
-          anchors.right: searchRec.left
-          anchors.rightMargin: 1/5 * parent.height
-          anchors.verticalCenter: parent.verticalCenter
-
-
-          Image{
-            id: back
-            source: "../assets/arrow.png"
-            anchors.fill: parent
-            anchors.centerIn: parent
-
-          }
-          MouseArea {
-              anchors.fill: parent
-              onPressed: {
-                back.scale = 0.8
-              }
-              onReleased: {
+      header: PageHeader {
+        id: pageHeader
+        flickable: flick
+        exposed: true
+        leadingActionBar {
+          numberOfSlots: 1
+          actions: [
+            Action {
+              id: back
+              iconName: "back"
+              onTriggered: {
                 content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
                 python.call('gemini.back', [], function(returnValue) {
                     adress.text = returnValue;
@@ -123,63 +44,109 @@ import io.thp.pyotherside 1.3
                         content.text = returnValue.content;
                     })
                 })
-                back.scale = 1
               }
+            }
+          ]
+        }
+
+        contents: Rectangle {
+          id: addressWrapper
+          radius: 15
+          color: "#F0F0F0"
+          anchors.fill: parent
+          anchors.topMargin: 15
+          anchors.bottomMargin: 15
+
+          TextInput {
+            id: adress
+            anchors {
+              fill: parent
+              centerIn: parent
+              leftMargin: 10
+              rightMargin: 10
+            }
+            verticalAlignment: Qt.AlignVCenter
+            horizontalAlignment: Qt.AlignLeft
+            text: "gemini://gemini.circumlunar.space/servers/"
+
+            onActiveFocusChanged: {
+              if (activeFocus) {
+                back.visible = false
+              } else {
+                back.visible = true
+              }
+            }
+
+            onAccepted: {
+              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+              python.call('gemini.main', [adress.text], function(returnValue) {
+                  console.assert(returnValue.status === 'success', returnValue.message);
+                  content.text = returnValue.content;
+              })
+              python.call('gemini.history', [adress.text], function(returnValue) {
+                  console.log("");
+              })
+              python.call('gemini.where_am_I', ["forward"], function(returnValue) {
+                  console.log("");
+              })
+            }
           }
         }
       }
-    }
-    Flickable {
-        id: flick
+      
+      Rectangle {
+        id: flickWrapper
+        anchors.fill: parent
+        color: "black"
 
-        anchors.left: parent.left
-        anchors.top: searchbar.bottom
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        contentHeight: content.paintedHeight
-        Text{
-          id: content
-          width: root.width
-          color: "#FFFFFFFF"
-          textFormat : Text.RichText
-          font.pointSize: 35
-          wrapMode: Text.WordWrap
-          onLinkActivated: {
-            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-            python.call('gemini.history', [link], function(returnValue) {})
-            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-            python.call('gemini.main', [link], function(returnValue) {
-                console.assert(returnValue.status === 'success', returnValue.message);
+        Flickable {
+          id: flick
+          anchors.fill: parent
+          contentHeight: content.paintedHeight
 
-                content.text = returnValue.content;
-                adress.text = link
-            })
+          Text{
+            id: content
+            width: root.width
+            color: "#FFFFFFFF"
+            textFormat : Text.RichText
+            font.pointSize: 35
+            wrapMode: Text.WordWrap
+            onLinkActivated: {
+              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+              python.call('gemini.history', [link], function(returnValue) {})
+              python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
+              python.call('gemini.main', [link], function(returnValue) {
+                  console.assert(returnValue.status === 'success', returnValue.message);
+
+                  content.text = returnValue.content;
+                  adress.text = link
+              })
+            }
           }
         }
+      }
 
+      Python {
+          id: python
 
-    }
+          Component.onCompleted: {
+              addImportPath(Qt.resolvedUrl('../src/'));
 
-    Python {
-        id: python
+              importModule('gemini', function() {
+                  console.log('module imported');
+                  python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
+                      console.assert(returnValue.status === 'success', returnValue.message);
 
-        Component.onCompleted: {
-            addImportPath(Qt.resolvedUrl('../src/'));
+                      content.text = returnValue.content;
+                  })
+                  python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
+                  python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
+              });
+          }
 
-            importModule('gemini', function() {
-                console.log('module imported');
-                python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-                    console.assert(returnValue.status === 'success', returnValue.message);
-
-                    content.text = returnValue.content;
-                })
-                python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
-                python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
-            });
-        }
-
-        onError: {
-            console.log('python error: ' + traceback);
-        }
-    }
+          onError: {
+              console.log('python error: ' + traceback);
+          }
+      }
+  }
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -66,6 +66,19 @@ MainView {
         ]
       }
 
+      trailingActionBar {
+        numberOfSlots: 1
+        actions: [
+          Action {
+            id: reload
+            iconName: "reload"
+
+            onTriggered: {
+              python.call('gemini.load', [adress.text])
+            }
+          }
+        ]
+      }
       contents: Rectangle {
         id: addressWrapper
         radius: 15

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -145,6 +145,10 @@ MainView {
             content.text = gemsite;
           })
 
+          python.setHandler('externalUrl', function(url) {
+             Qt.openUrlExternally(url);
+          })
+
           // Load the homepage
           python.call('gemini.goto', ['gemini://gemini.circumlunar.space/servers/'])
         });

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -22,7 +22,7 @@ import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 
 MainView {
-  applicationName: "Gem"
+  applicationName: "gem.aaron"
   backgroundColor: "#515151"
 
   Page {
@@ -41,15 +41,7 @@ MainView {
             iconName: "back"
 
             onTriggered: {
-              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-
-              python.call('gemini.back', [], function(returnValue) {
-                adress.text = returnValue;
-                python.call('gemini.main', [adress.text], function(returnValue) {
-                  console.assert(returnValue.status === 'success', returnValue.message);
-                  content.text = returnValue.content;
-                })
-              })
+              python.call('gemini.back', [])
             }
           }
         ]
@@ -85,18 +77,7 @@ MainView {
           }
 
           onAccepted: {
-            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-
-            python.call('gemini.main', [adress.text], function(returnValue) {
-              console.assert(returnValue.status === 'success', returnValue.message);
-              content.text = returnValue.content;
-            })
-            python.call('gemini.history', [adress.text], function(returnValue) {
-              console.log("");
-            })
-            python.call('gemini.where_am_I', ["forward"], function(returnValue) {
-              console.log("");
-            })
+            python.call('gemini.goto', [adress.text])
           }
         }
       }
@@ -122,16 +103,7 @@ MainView {
         wrapMode: Text.WordWrap
 
         onLinkActivated: {
-          content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-
-          python.call('gemini.history', [link], function(returnValue) {})
-          python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-          python.call('gemini.main', [link], function(returnValue) {
-            console.assert(returnValue.status === 'success', returnValue.message);
-
-            content.text = returnValue.content;
-            adress.text = link
-          })
+          python.call('gemini.goto', [link])
         }
       }
     }
@@ -142,17 +114,20 @@ MainView {
       Component.onCompleted: {
         addImportPath(Qt.resolvedUrl('../src/'));
 
-        importModule('gemini', function() {
+        importNames('gemini', ['gemini'], function() {
           console.log('module imported');
 
-          python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-            console.assert(returnValue.status === 'success', returnValue.message);
-
-            content.text = returnValue.content;
+          python.setHandler('loading', function(url) {
+            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+            adress.text = url;
           })
 
-          python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
-          python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {});
+          python.setHandler('onLoad', function(gemsite) {
+            content.text = gemsite;
+          })
+
+          // Load the homepage
+          python.call('gemini.goto', ['gemini://gemini.circumlunar.space/servers/'])
         });
       }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -75,7 +75,7 @@ MainView {
             leftMargin: 10
             rightMargin: 10
           }
-          
+
           onActiveFocusChanged: {
             if (activeFocus) {
               back.visible = false
@@ -101,11 +101,17 @@ MainView {
         }
       }
     }
-    
+
     Flickable {
       id: flick
       anchors.fill: parent
       contentHeight: content.paintedHeight
+
+      MouseArea {
+        // This is to remove focus from the address bar when tapping off of it
+        anchors.fill: parent
+        onClicked: forceActiveFocus()
+      }
 
       Text{
         id: content

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -42,7 +42,7 @@ MainView {
             visible: false
 
             onTriggered: {
-              python.call('gemini.forward', [])
+              python.call('gemini.forward')
             }
 
             Component.onCompleted: {
@@ -60,7 +60,7 @@ MainView {
             iconName: "go-previous"
 
             onTriggered: {
-              python.call('gemini.back', [])
+              python.call('gemini.back')
             }
           }
         ]
@@ -149,8 +149,7 @@ MainView {
              Qt.openUrlExternally(url);
           })
 
-          // Load the homepage
-          python.call('gemini.goto', ['gemini://gemini.circumlunar.space/servers/'])
+          python.call('gemini.load_initial_page')
         });
       }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -22,6 +22,9 @@ import Qt.labs.settings 1.0
 import io.thp.pyotherside 1.3
 
 MainView {
+  applicationName: "Gem"
+  backgroundColor: "#515151"
+
   Page {
       id: root
 
@@ -94,34 +97,28 @@ MainView {
         }
       }
       
-      Rectangle {
-        id: flickWrapper
+      Flickable {
+        id: flick
         anchors.fill: parent
-        color: "black"
+        contentHeight: content.paintedHeight
 
-        Flickable {
-          id: flick
-          anchors.fill: parent
-          contentHeight: content.paintedHeight
+        Text{
+          id: content
+          width: root.width
+          color: "#FFFFFFFF"
+          textFormat : Text.RichText
+          font.pointSize: 35
+          wrapMode: Text.WordWrap
+          onLinkActivated: {
+            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+            python.call('gemini.history', [link], function(returnValue) {})
+            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
+            python.call('gemini.main', [link], function(returnValue) {
+                console.assert(returnValue.status === 'success', returnValue.message);
 
-          Text{
-            id: content
-            width: root.width
-            color: "#FFFFFFFF"
-            textFormat : Text.RichText
-            font.pointSize: 35
-            wrapMode: Text.WordWrap
-            onLinkActivated: {
-              content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-              python.call('gemini.history', [link], function(returnValue) {})
-              python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-              python.call('gemini.main', [link], function(returnValue) {
-                  console.assert(returnValue.status === 'success', returnValue.message);
-
-                  content.text = returnValue.content;
-                  adress.text = link
-              })
-            }
+                content.text = returnValue.content;
+                adress.text = link
+            })
           }
         }
       }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -71,6 +71,7 @@ MainView {
             verticalAlignment: Qt.AlignVCenter
             horizontalAlignment: Qt.AlignLeft
             text: "gemini://gemini.circumlunar.space/servers/"
+            layer.enabled: true
 
             onActiveFocusChanged: {
               if (activeFocus) {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -26,125 +26,133 @@ MainView {
   backgroundColor: "#515151"
 
   Page {
-      id: root
+    id: root
 
-      header: PageHeader {
-        id: pageHeader
-        flickable: flick
-        exposed: true
-        leadingActionBar {
-          numberOfSlots: 1
-          actions: [
-            Action {
-              id: back
-              iconName: "back"
-              onTriggered: {
-                content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-                python.call('gemini.back', [], function(returnValue) {
-                    adress.text = returnValue;
-                    python.call('gemini.main', [adress.text], function(returnValue) {
-                        console.assert(returnValue.status === 'success', returnValue.message);
-                        content.text = returnValue.content;
-                    })
-                })
-              }
-            }
-          ]
-        }
+    header: PageHeader {
+      id: pageHeader
+      flickable: flick
+      exposed: true
 
-        contents: Rectangle {
-          id: addressWrapper
-          radius: 15
-          color: "#F0F0F0"
-          anchors.fill: parent
-          anchors.topMargin: 15
-          anchors.bottomMargin: 15
+      leadingActionBar {
+        numberOfSlots: 1
+        actions: [
+          Action {
+            id: back
+            iconName: "back"
 
-          TextInput {
-            id: adress
-            anchors {
-              fill: parent
-              centerIn: parent
-              leftMargin: 10
-              rightMargin: 10
-            }
-            verticalAlignment: Qt.AlignVCenter
-            horizontalAlignment: Qt.AlignLeft
-            text: "gemini://gemini.circumlunar.space/servers/"
-            layer.enabled: true
-
-            onActiveFocusChanged: {
-              if (activeFocus) {
-                back.visible = false
-              } else {
-                back.visible = true
-              }
-            }
-
-            onAccepted: {
+            onTriggered: {
               content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-              python.call('gemini.main', [adress.text], function(returnValue) {
+
+              python.call('gemini.back', [], function(returnValue) {
+                adress.text = returnValue;
+                python.call('gemini.main', [adress.text], function(returnValue) {
                   console.assert(returnValue.status === 'success', returnValue.message);
                   content.text = returnValue.content;
-              })
-              python.call('gemini.history', [adress.text], function(returnValue) {
-                  console.log("");
-              })
-              python.call('gemini.where_am_I', ["forward"], function(returnValue) {
-                  console.log("");
+                })
               })
             }
           }
-        }
+        ]
       }
-      
-      Flickable {
-        id: flick
+
+      contents: Rectangle {
+        id: addressWrapper
+        radius: 15
+        color: "#F0F0F0"
         anchors.fill: parent
-        contentHeight: content.paintedHeight
+        anchors.topMargin: 15
+        anchors.bottomMargin: 15
 
-        Text{
-          id: content
-          width: root.width
-          color: "#FFFFFFFF"
-          textFormat : Text.RichText
-          font.pointSize: 35
-          wrapMode: Text.WordWrap
-          onLinkActivated: {
+        TextInput {
+          id: adress
+          verticalAlignment: Qt.AlignVCenter
+          horizontalAlignment: Qt.AlignLeft
+          text: "gemini://gemini.circumlunar.space/servers/"
+          layer.enabled: true
+          anchors {
+            fill: parent
+            centerIn: parent
+            leftMargin: 10
+            rightMargin: 10
+          }
+          
+          onActiveFocusChanged: {
+            if (activeFocus) {
+              back.visible = false
+            } else {
+              back.visible = true
+            }
+          }
+
+          onAccepted: {
             content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
-            python.call('gemini.history', [link], function(returnValue) {})
-            python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
-            python.call('gemini.main', [link], function(returnValue) {
-                console.assert(returnValue.status === 'success', returnValue.message);
 
-                content.text = returnValue.content;
-                adress.text = link
+            python.call('gemini.main', [adress.text], function(returnValue) {
+              console.assert(returnValue.status === 'success', returnValue.message);
+              content.text = returnValue.content;
+            })
+            python.call('gemini.history', [adress.text], function(returnValue) {
+              console.log("");
+            })
+            python.call('gemini.where_am_I', ["forward"], function(returnValue) {
+              console.log("");
             })
           }
         }
       }
+    }
+    
+    Flickable {
+      id: flick
+      anchors.fill: parent
+      contentHeight: content.paintedHeight
 
-      Python {
-          id: python
+      Text{
+        id: content
+        width: root.width
+        color: "#FFFFFFFF"
+        textFormat : Text.RichText
+        font.pointSize: 35
+        wrapMode: Text.WordWrap
 
-          Component.onCompleted: {
-              addImportPath(Qt.resolvedUrl('../src/'));
+        onLinkActivated: {
+          content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
 
-              importModule('gemini', function() {
-                  console.log('module imported');
-                  python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
-                      console.assert(returnValue.status === 'success', returnValue.message);
+          python.call('gemini.history', [link], function(returnValue) {})
+          python.call('gemini.where_am_I', ["forward"], function(returnValue) {})
+          python.call('gemini.main', [link], function(returnValue) {
+            console.assert(returnValue.status === 'success', returnValue.message);
 
-                      content.text = returnValue.content;
-                  })
-                  python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
-                  python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {})
-              });
-          }
-
-          onError: {
-              console.log('python error: ' + traceback);
-          }
+            content.text = returnValue.content;
+            adress.text = link
+          })
+        }
       }
+    }
+
+    Python {
+      id: python
+
+      Component.onCompleted: {
+        addImportPath(Qt.resolvedUrl('../src/'));
+
+        importModule('gemini', function() {
+          console.log('module imported');
+
+          python.call('gemini.main', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {
+            console.assert(returnValue.status === 'success', returnValue.message);
+
+            content.text = returnValue.content;
+          })
+
+          python.call('gemini.where_am_I', ['forward'], function(returnValue) {})
+          python.call('gemini.history', ['gemini://gemini.circumlunar.space/servers/'], function(returnValue) {});
+        });
+      }
+
+      onError: {
+        console.log('python error: ' + traceback);
+      }
+    }
   }
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -34,11 +34,30 @@ MainView {
       exposed: true
 
       leadingActionBar {
-        numberOfSlots: 1
+        numberOfSlots: 2
         actions: [
           Action {
+            id: forward
+            iconName: "go-next"
+            visible: false
+
+            onTriggered: {
+              python.call('gemini.forward', [])
+            }
+
+            Component.onCompleted: {
+              python.setHandler('showForward', function() {
+                forward.visible = true
+              });
+
+              python.setHandler('hideForward', function() {
+                forward.visible = false
+              })
+            }
+          },
+          Action {
             id: back
-            iconName: "back"
+            iconName: "go-previous"
 
             onTriggered: {
               python.call('gemini.back', [])

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -67,6 +67,7 @@ class Gemini:
 
     def get_site(self, url):
         parsed_url = urllib.parse.urlparse(url)
+
         while True:
             s = socket.create_connection((parsed_url.netloc, 1965))
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
@@ -185,6 +186,9 @@ class Gemini:
         return self.load(url)
 
     def goto(self, url):
+        if url.split(':')[0] in ["https", "http:"]:
+            return pyotherside.send('externalUrl', url)
+
         self.history.append(url)
 
         # Reset the future.

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -12,193 +12,185 @@ import ssl
 import tempfile
 import textwrap
 import urllib.parse
-def makeDirs():
-    try:
-        os.mkdir("/home/phablet/.local/share/gem.aaron/")
-    except:
-        pass
+import pyotherside
 
-def absolutise_url(base, relative):
-    # Absolutise relative links
-    if "://" not in relative:
-        # Python's URL tools somehow only work with known schemes?
-        base = base.replace("gemini://","http://")
-        relative = urllib.parse.urljoin(base, relative)
-        relative = relative.replace("http://", "gemini://")
-    return relative
+storage_dir = "/home/phablet/.local/share/gem.aaron"
 
-def get_site(url):
-    parsed_url = urllib.parse.urlparse(url)
-    while True:
-        s = socket.create_connection((parsed_url.netloc, 1965))
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
-        s = context.wrap_socket(s, server_hostname = parsed_url.netloc)
-        s.sendall((url + '\r\n').encode("UTF-8"))
-        # Get header and check for redirects
-        fp = s.makefile("rb")
-        header = fp.readline()
-        header = header.decode("UTF-8").strip()
-        status, mime = header.split()[:2]
-        # Handle input requests
-        if status.startswith("1"):
-            # Prompt
-            query = input("INPUT" + mime + "> ")
-            url += "?" + urllib.parse.quote(query) # Bit lazy...
-            # Follow redirects
-        elif status.startswith("3"):
-            url = absolutise_url(url, mime)
-            parsed_url = urllib.parse.urlparse(url)
-        # Otherwise, we're done.
-        else:
-            mime, mime_opts = cgi.parse_header(mime)
-            body = fp.read()
-            body = body.decode(mime_opts.get("charset","UTF-8"))
-            return str(body)
-            break
+class Gemini:
+    def __init__(self):
+        self.makeDirs()
+        # load position
+        position_data = self.read_file("where_am_I.txt")
+        self.position = int(position_data if position_data != None else '0')
+        # Load history
+        history_data = self.read_file("history.txt")
+        self.history = history_data if history_data != None else []
+        # Load future
+        future_data = self.read_file("future.txt")
+        self.future = future_data if future_data != None else []
 
-def get_links(body, url):
-    links = []
-    for line in body.splitlines():
-        if line.startswith("=>"):
-            bits = line[2:].strip().split(maxsplit=1)
-            link_url = bits[0]
-            link_url = absolutise_url(url, link_url)
-            links.append(link_url)
-    return links
+    def read_file(self, filename):
+        f = self.open_file(filename, "rb")
 
+        if f == None:
+            return None
 
+        f_data = f.read()
+        f.close()
 
-def instert_html_links(body, links):
-    mdBody = ""
-    for line in body.splitlines():
-        if "=>" in line:
-            try:
-                line =  '<a style="color: #FFC0CB" href="'+links[0]+'">'+line+'</a>'
-                del links[0]
-                mdBody += line
-                mdBody += "<br>"
-                mdBody += "<br>"
-                #print("here")
-            except:
-                mdBody += line
-                #print("err")
-                pass
-        elif line.startswith("#"):
-            if line.startswith("###"):
-                line = line.replace("###", "<h3>")
-                line += "</h3>"
-                mdBody += line
-            elif line.startswith("##"):
-                line = line.replace("##", "<h2>")
-                line += "</h2>"
-                mdBody += line
-            elif line.startswith("#"):
-                line = line.replace("#", "<h1>")
-                line += "</h1>"
-                mdBody += line
+        return f_data
+
+    def save_data(self):
+        position_file = self.open_file("where_am_I.txt", "wb")
+        history_file = self.open_file("history.txt", "wb")
+
+        position_file.write(str(self.position))
+        history_file.write(','.join(self.history))
+
+        position_file.close()
+        history_file.close()
+
+    def makeDirs(self):
+        try:
+            os.mkdir(storage_dir)
+        except:
+            pass
+
+    def absolutise_url(self, base, relative):
+        # Absolutise relative links
+        if "://" not in relative:
+            # Python's URL tools somehow only work with known schemes?
+            base = base.replace("gemini://","http://")
+            relative = urllib.parse.urljoin(base, relative)
+            relative = relative.replace("http://", "gemini://")
+        return relative
+
+    def get_site(self, url):
+        parsed_url = urllib.parse.urlparse(url)
+        while True:
+            s = socket.create_connection((parsed_url.netloc, 1965))
+            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+            s = context.wrap_socket(s, server_hostname = parsed_url.netloc)
+            s.sendall((url + '\r\n').encode("UTF-8"))
+            # Get header and check for redirects
+            fp = s.makefile("rb")
+            header = fp.readline()
+            header = header.decode("UTF-8").strip()
+            status, mime = header.split()[:2]
+            # Handle input requests
+            if status.startswith("1"):
+                # Prompt
+                query = input("INPUT" + mime + "> ")
+                url += "?" + urllib.parse.quote(query) # Bit lazy...
+                # Follow redirects
+            elif status.startswith("3"):
+                url = self.absolutise_url(url, mime)
+                parsed_url = urllib.parse.urlparse(url)
+            # Otherwise, we're done.
             else:
-                pass
+                mime, mime_opts = cgi.parse_header(mime)
+                body = fp.read()
+                body = body.decode(mime_opts.get("charset","UTF-8"))
+                return str(body)
+                break
 
-        else:
-            #print("nolink")
-            mdBody += line + "\n"
-            mdBody += "<br>"
-            mdBody += "<br>"
-    return mdBody
+    def get_links(self, body, url):
+        links = []
+        for line in body.splitlines():
+            if line.startswith("=>"):
+                bits = line[2:].strip().split(maxsplit=1)
+                link_url = bits[0]
+                link_url = self.absolutise_url(url, link_url)
+                links.append(link_url)
+        return links
 
 
-def where_am_I(direction):
-    try:
+
+    def instert_html_links(self, body, links):
+        mdBody = ""
+        for line in body.splitlines():
+            if "=>" in line:
+                try:
+                    line =  '<a style="color: #FFC0CB" href="'+links[0]+'">'+line+'</a>'
+                    del links[0]
+                    mdBody += line
+                    mdBody += "<br>"
+                    mdBody += "<br>"
+                    #print("here")
+                except:
+                    mdBody += line
+                    #print("err")
+                    pass
+            elif line.startswith("#"):
+                if line.startswith("###"):
+                    line = line.replace("###", "<h3>")
+                    line += "</h3>"
+                    mdBody += line
+                elif line.startswith("##"):
+                    line = line.replace("##", "<h2>")
+                    line += "</h2>"
+                    mdBody += line
+                elif line.startswith("#"):
+                    line = line.replace("#", "<h1>")
+                    line += "</h1>"
+                    mdBody += line
+                else:
+                    pass
+
+            else:
+                #print("nolink")
+                mdBody += line + "\n"
+                mdBody += "<br>"
+                mdBody += "<br>"
+        return mdBody
+
+    def open_file(self, filename, mode="r+"):
         try:
-            makeDirs()
-            f = open("where_am_I.txt", "r")
+            f = open(filename, mode) if os.path.exists(filename) else None
         except:
-            makeDirs()
-            f = open("/home/phablet/.local/share/gem.aaron/where_am_I.txt", "r")
-    except:
+            file_path = "{}/{}".format(storage_dir, filename)
+            f = open(file_path, mode) if os.path.exists(file_path) else None
+
+        return f
+
+    def top(self, stack):
+        stack_size = len(stack)
+
+        if stack_size == 0:
+            return None
+
+        return stack[stack_size - 1]
+
+    def back(self):
+        if len(self.history) == 1:
+            return self.load(self.history[0])
+
+        self.future.append(self.history.pop())
+        url = self.top(self.history)
+        print('back', self.history)
+
+        return self.load(url)
+
+    def goto(self, url):
+        self.history.append(url)
+        print('goto', self.history)
+
+        return self.load(url)
+
+    def load(self, url):
+        pyotherside.send('loading', url)
         try:
-            makeDirs()
-            f = open("where_am_I.txt", "w+")
-        except:
-            makeDirs()
-            f = open("/home/phablet/.local/share/gem.aaron/where_am_I.txt", "w+")
-    current = f.read()
+            gemsite = self.get_site(url)
+            gemsite = self.instert_html_links(gemsite, self.get_links(gemsite, url))
 
-    if direction == "forward":
-        try:
-            current =int(current) + 1
-        except:
-            current = int(0)
-    if direction == "backward" and int(current) > 0:
-        try:
-            current =int(current) - 1
-        except:
-            current = int(0)
+            pyotherside.send('onLoad', gemsite)
+        except Exception as e:
+            print("Error:", e.message)
+            pyotherside.send('onLoad', "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯")
 
-    f.close()
-    try:
-        f = open("where_am_I.txt", "w")
-    except:
-        f = open("/home/phablet/.local/share/gem.aaron/where_am_I.txt", "w")
-    f.write(str(current))
+        return;
 
-
-    f.close()
-    return current
-
-def history(url):
-    try:
-        makeDirs()
-        f = open("history.txt", "a")
-    except:
-        makeDirs()
-        f = open("/home/phablet/.local/share/gem.aaron/history.txt", "a")
-    f.write(","+url)
-    f.close()
-
-def back():
-    index = where_am_I("backward")
-    try:
-        makeDirs()
-        f = open("history.txt", "r")
-    except:
-        makeDirs()
-        f = open("/home/phablet/.local/share/gem.aaron/history.txt", "r")
-    history = f.read().split(",")
-    url = history[index+1]
-    f.close()
-    try:
-        makeDirs()
-        f = open("history.txt", "w")
-    except:
-        makeDirs()
-        f = open("/home/phablet/.local/share/gem.aaron/history.txt", "w")
-    newHist = "" #were rewriting history lmao
-    for element in history[1:index+2]:
-         newHist += "," + element
-    f.write(newHist)
-    f.close()
-
-    return str(url)
-
-def main(url):
-    try:
-        gemsite = get_site(url)
-        returnValue = instert_html_links(gemsite, get_links(gemsite, url))
-#        where_am_I("forward")
-#        history(url)
-        return {
-            'status': 'success',
-            'content': returnValue
-        }
-    except Exception as e:
-#        where_am_I("forward")
-#        history(url)
-        return {
-            'status': 'error',
-            'content': "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯",
-            'message': str(e)
-        }
-        return
+gemini = Gemini()
+pyotherside.atexit(gemini.save_data)

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -41,13 +41,13 @@ class Gemini:
         return f_data
 
     def save_data(self):
-        position_file = self.open_file("where_am_I.txt", "wb")
+        future_file = self.open_file("future.txt", "wb")
         history_file = self.open_file("history.txt", "wb")
 
-        position_file.write(str(self.position))
-        history_file.write(','.join(self.history))
+        future_file.write(self.future)
+        history_file.write(self.history)
 
-        position_file.close()
+        future_file.close()
         history_file.close()
 
     def makeDirs(self):
@@ -169,13 +169,27 @@ class Gemini:
 
         self.future.append(self.history.pop())
         url = self.top(self.history)
-        print('back', self.history)
+        
+        if len(self.future) > 0:
+            pyotherside.send('showForward')
+
+        return self.load(url)
+
+    def forward(self):
+        self.history.append(self.future.pop())
+        url = self.top(self.history)
+
+        if len(self.future) == 0:
+            pyotherside.send('hideForward')
 
         return self.load(url)
 
     def goto(self, url):
         self.history.append(url)
-        print('goto', self.history)
+
+        # Reset the future.
+        self.future = []
+        pyotherside.send('hideForward')
 
         return self.load(url)
 


### PR DESCRIPTION
Here is my implementation of page caching. I decided that we should only load cached pages when we click back or forward, the reason being this:

If I click back/forward I want to see the same thing that I just saw, but if I click a link or enter a new url I want to see the most recent content from that link/address. 

Part of my motivation is that the elpher gopher/gemini client in emacs (what I use on desktop) uses the cache for everything. It is really annoying because there are some pages that are dynamically generated. Anyways, I've also implemented cache pruning so it will only cache up to 5 pages in history or future. That way we aren't too aggressively caching.

Please let me know if you want any changes.