### PR TITLE
Feature/remember scroll position

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -43,7 +43,7 @@ MainView {
             visible: false
 
             onTriggered: {
-              python.call('gemini.forward')
+              python.call('gemini.forward', [flick.contentY])
             }
 
             Component.onCompleted: {
@@ -61,7 +61,7 @@ MainView {
             iconName: "go-previous"
 
             onTriggered: {
-              python.call('gemini.back')
+              python.call('gemini.back', [flick.contentY])
             }
           }
         ]
@@ -75,7 +75,7 @@ MainView {
             iconName: "reload"
 
             onTriggered: {
-              python.call('gemini.load', [adress.text])
+              python.call('gemini.reload', [adress.text, flick.contentY])
             }
           },
           Action {
@@ -115,7 +115,7 @@ MainView {
           }
 
           onAccepted: {
-            python.call('gemini.goto', [adress.text])
+            python.call('gemini.goto', [adress.text, flick.contentY])
           }
         }
       }
@@ -177,7 +177,7 @@ MainView {
         wrapMode: Text.WordWrap
 
         onLinkActivated: {
-          python.call('gemini.goto', [link])
+          python.call('gemini.goto', [link, flick.contentY])
         }
       }
     }
@@ -243,7 +243,7 @@ MainView {
                 onClicked: {
                   python.call('bookmark.allocate', [modelData], function(url) {
                     console.log(url)
-                    python.call('gemini.goto', [url])
+                    python.call('gemini.goto', [url, flick.contentY])
                   })
                   bottomEdge.collapse()
 
@@ -290,8 +290,12 @@ MainView {
             adress.text = url;
           })
 
-          python.setHandler('onLoad', function(gemsite) {
+          python.setHandler('onLoad', function(gemsite, scrollHeight) {
             content.text = gemsite;
+
+            if (scrollHeight) {
+              flick.contentY = scrollHeight;
+            }
           })
 
           python.setHandler('externalUrl', function(url) {

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -5,19 +5,15 @@ I wouldnt have been able to do this without this resource. Thanks for the awsome
 
 
 import cgi
-import mailcap
 import os
 import socket
 import ssl
-import tempfile
-import textwrap
 import urllib.parse
 import pyotherside
 import pickle
 import time
 import re
 import gopher
-
 
 storage_dir = "/home/phablet/.local/share/gem.aaron"
 

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -27,8 +27,26 @@ class Gemini:
         # Load future
         future_data = self.read_file("future.dat")
         self.future = future_data if future_data != None else []
+
+        self.migrate_to_page_context()
+
         # cache_limit prevents all pages from being cached
         self.cache_limit = 5
+
+    def migrate_to_page_context(self):
+        # Migrate from simple url strings in the history to dictionaries
+        # The dictionaries currently contain the url and scroll height of the page.
+        # In the future they can also hold other information for page context.
+
+        self.history = [
+            self.create_page_context(item, 0) if type(item) is str else item
+            for item in self.history
+        ]
+
+        self.future = [
+            self.create_page_context(item, 0) if type(item) is str else item
+            for item in self.future
+        ]
 
     def read_file(self, filename):
         filepath = "{}/{}".format(storage_dir, filename)

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -182,28 +182,45 @@ class Gemini:
 
         return stack[stack_size - 1]
 
-    def back(self):
+    def create_page_context(self, url, scroll_height):
+        return {
+            "url": url,
+            "scroll_height": scroll_height
+        }
+
+    def update_scroll_height(self, scroll_height):
+        # Record scroll height for current page (top page on the stack)
+        current_page = self.top(self.history)
+        current_page["scroll_height"] = scroll_height
+        self.history.pop()
+        self.history.append(current_page)
+
+    def back(self, scroll_height):
         if len(self.history) == 1:
             return self.load(self.history[0], True)
 
+        self.update_scroll_height(scroll_height)
+
         self.future.append(self.history.pop())
-        url = self.top(self.history)
+        page = self.top(self.history)
 
         if len(self.future) > 0:
             pyotherside.send('showForward')
 
-        return self.load(url, True)
+        return self.load(page, True)
 
-    def forward(self):
+    def forward(self, scroll_height):
+        self.update_scroll_height(scroll_height)
+
         self.history.append(self.future.pop())
-        url = self.top(self.history)
+        page = self.top(self.history)
 
         if len(self.future) == 0:
             pyotherside.send('hideForward')
 
-        return self.load(url, True)
+        return self.load(page, True)
 
-    def goto(self, _url):
+    def goto(self, _url, scroll_height=0):
         if "://" not in _url:
             url = "gemini://" + _url
         else:
@@ -212,29 +229,42 @@ class Gemini:
         if url.split(':')[0] in ["https", "http:"]:
             return pyotherside.send('externalUrl', url)
 
+        self.update_scroll_height(scroll_height)
 
-
-        self.history.append(url)
+        page = self.create_page_context(url, 0)
+        self.history.append(page)
 
         # Reset the future.
         self.remove_from_cache(self.future)
         self.future = []
         pyotherside.send('hideForward')
 
-        return self.load(url)
+        return self.load(page)
+
+    def reload(self, url, scroll_height):
+        page = self.create_page_context(url, scroll_height)
+
+        return self.load(page)
 
     def load_initial_page(self):
         if len(self.history) > 0:
-            url = self.top(self.history)
-            self.load(url)
+            page = self.top(self.history)
+            self.load(page)
         else:
-            self.load("gemini://gemini.circumlunar.space/servers/")
+            home_page = self.create_page_context("gemini://gemini.circumlunar.space/servers/", 0)
+            self.load(home_page)
 
     def cache_page(self, url, content):
-        self.page_cache[url] = {
-            "content": content,
-            "timestamp": time.time()
-        }
+        cache_obj = {}
+
+        if url in self.page_cache:
+            cache_obj = self.page_cache[url]
+
+
+        cache_obj["content"] =  content
+        cache_obj["timestamp"] =  time.time()
+
+        self.page_cache[url] = cache_obj
 
     def prune_cache(self):
         # Find urls that are too old to be cached
@@ -245,27 +275,34 @@ class Gemini:
         if old_urls:
             self.remove_from_cache(old_urls)
 
-    def remove_from_cache(self, url_list):
+    def remove_from_cache(self, context_list):
+        url_list = [page['url'] for page in context_list]
+
         # Removes cached values for the provided list of urls
         for url in url_list:
             if url in self.page_cache:
                 del self.page_cache[url]
 
-    def load(self, url, using_cache = False):
+    def load(self, page_context, using_cache = False):
+        url = page_context["url"]
+        scroll_height = page_context['scroll_height'] if 'scroll_height' in page_context else 0
+
         if len(self.history) > self.cache_limit or len(self.future) > self.cache_limit:
             self.prune_cache()
-        self.prune_cache()
+
         pyotherside.send('loading', url)
 
         if using_cache and url in self.page_cache:
-            return pyotherside.send('onLoad', self.page_cache[url]['content'])
+            cache_obj = self.page_cache[url]
+
+            return pyotherside.send('onLoad', cache_obj['content'], scroll_height)
 
 
         if "gopher://" in url or "Gopher://" in url:
             try:
                 gophsite = gopher.get_content(url)
                 self.cache_page(url, gophsite)
-                pyotherside.send('onLoad', gophsite)
+                pyotherside.send('onLoad', gophsite, scroll_height)
             except Exception as e:
                 print("Error:", e)
                 pyotherside.send('onLoad', "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯")
@@ -278,7 +315,7 @@ class Gemini:
             gemsite = self.instert_html_links(gemsite, self.get_links(gemsite, url))
             self.cache_page(url, gemsite)
 
-            pyotherside.send('onLoad', gemsite)
+            pyotherside.send('onLoad', gemsite, scroll_height)
         except Exception as e:
             print("Error:", e)
             pyotherside.send('onLoad', "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯")


### PR DESCRIPTION
Purpose:
This PR adds support for remembering how far you were scrolled down on a page when you leave that page (clicking a link, hitting back/forward, or opening a bookmark).

Reason:
I've found that while browsing in Gem I find myself doing a lot of scrolling to get to where I was on a page after clicking on a link. This is especially annoying on CAPCOM where you have to scroll down a ways before you see the feed, if look at a post, then go back to CAPCOM you need to scroll all the way down again.

Notes:
In order to do this I had to store the scroll_height with the urls in the history, so I created 'page contexts' which is really just a dict with `url` and `scroll_height` keys. As such this PR touches pretty much every function related to navigation to support page contexts.

Please let me know if there are any changes you would like made and if there are any bugs you find.