### PR TITLE
Feature/text input support

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -184,12 +184,12 @@ MainView {
 
     Component {
       id: inputComponent
+
       Dialog {
         id: inputDialog
-        title: "Enter input"
+        title: "Input requested"
         TextField {
           id: inputfield
-          placeholderText: "input"
           hasClearButton: true
         }
         Button {
@@ -324,8 +324,8 @@ MainView {
              Qt.openUrlExternally(url);
           })
 
-          python.setHandler('requestInput', function() {
-            PopupUtils.open(inputComponent)
+          python.setHandler('requestInput', function(message) {
+            PopupUtils.open(inputComponent, null, { 'text': message })
           })
 
           python.call('gemini.load_initial_page')

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -190,10 +190,19 @@ MainView {
         title: "Input requested"
 
         property bool isSecret: false
+
+        function submit() {
+          forceActiveFocus()
+          python.call('gemini.handle_input', [inputfield.text])
+          PopupUtils.close(inputDialog)
+        }
+
         TextField {
           id: inputfield
           hasClearButton: true
           echoMode: isSecret ? TextInput.Password : TextInput.Normal
+
+          onAccepted: submit()
         }
         Button {
           text: "cancel"
@@ -202,11 +211,7 @@ MainView {
         Button {
           text: "send"
           color: UbuntuColors.orange
-          onClicked: {
-            forceActiveFocus()
-            python.call('gemini.handle_input', [inputfield.text])
-            PopupUtils.close(inputDialog)
-          }
+          onClicked: submit()
         }
       }
     }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -188,9 +188,12 @@ MainView {
       Dialog {
         id: inputDialog
         title: "Input requested"
+
+        property bool isSecret: false
         TextField {
           id: inputfield
           hasClearButton: true
+          echoMode: isSecret ? TextInput.Password : TextInput.Normal
         }
         Button {
           text: "cancel"
@@ -324,8 +327,8 @@ MainView {
              Qt.openUrlExternally(url);
           })
 
-          python.setHandler('requestInput', function(message) {
-            PopupUtils.open(inputComponent, null, { 'text': message })
+          python.setHandler('requestInput', function(message, isSecret) {
+            PopupUtils.open(inputComponent, null, { 'text': message, 'isSecret': isSecret })
           })
 
           python.call('gemini.load_initial_page')

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -182,6 +182,32 @@ MainView {
       }
     }
 
+    Component {
+      id: inputComponent
+      Dialog {
+        id: inputDialog
+        title: "Enter input"
+        TextField {
+          id: inputfield
+          placeholderText: "input"
+          hasClearButton: true
+        }
+        Button {
+          text: "cancel"
+          onClicked: PopupUtils.close(inputDialog)
+        }
+        Button {
+          text: "send"
+          color: UbuntuColors.orange
+          onClicked: {
+            forceActiveFocus()
+            python.call('gemini.handle_input', [inputfield.text])
+            PopupUtils.close(inputDialog)
+          }
+        }
+      }
+    }
+
 
     BottomEdge {
       id: bottomEdge
@@ -296,6 +322,10 @@ MainView {
 
           python.setHandler('externalUrl', function(url) {
              Qt.openUrlExternally(url);
+          })
+
+          python.setHandler('requestInput', function() {
+            PopupUtils.open(inputComponent)
           })
 
           python.call('gemini.load_initial_page')

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -95,24 +95,23 @@ class Gemini:
             fp = s.makefile("rb")
             header = fp.readline()
             header = header.decode("UTF-8").strip()
-            status, mime = header.split()[:2]
+            status, meta = header.split()[:2]
             # Handle input requests
             if status.startswith("1"):
-                # Prompt
-                pyotherside.send('requestInput')
+                # Prompt with message from server (in meta)
+                pyotherside.send('requestInput', meta)
                 self.current_url = url
                 break
                 # Follow redirects
             elif status.startswith("3"):
-                url = self.absolutise_url(url, mime)
+                url = self.absolutise_url(url, meta)
                 parsed_url = urllib.parse.urlparse(url)
             # Otherwise, we're done.
             else:
-                mime, mime_opts = cgi.parse_header(mime)
+                mime, mime_opts = cgi.parse_header(meta)
                 body = fp.read()
                 body = body.decode(mime_opts.get("charset","UTF-8"))
                 return str(body)
-                break
 
     def handle_input(self, inputText):
         new_url = self.current_url

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -33,6 +33,7 @@ class Gemini:
         self.future = future_data if future_data != None else []
         # cache_limit prevents all pages from being cached
         self.cache_limit = 5
+        self.current_url = None
 
     def read_file(self, filename):
         filepath = "{}/{}".format(storage_dir, filename)
@@ -98,8 +99,9 @@ class Gemini:
             # Handle input requests
             if status.startswith("1"):
                 # Prompt
-                query = input("INPUT" + mime + "> ")
-                url += "?" + urllib.parse.quote(query) # Bit lazy...
+                pyotherside.send('requestInput')
+                self.current_url = url
+                break
                 # Follow redirects
             elif status.startswith("3"):
                 url = self.absolutise_url(url, mime)
@@ -111,6 +113,13 @@ class Gemini:
                 body = body.decode(mime_opts.get("charset","UTF-8"))
                 return str(body)
                 break
+
+    def handle_input(self, inputText):
+        new_url = self.current_url
+        new_url += "?" + urllib.parse.quote(inputText)
+
+        self.current_url = None
+        self.goto(new_url)
 
     def get_links(self, body, url):
         links = []

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -99,7 +99,10 @@ class Gemini:
             # Handle input requests
             if status.startswith("1"):
                 # Prompt with message from server (in meta)
-                pyotherside.send('requestInput', meta)
+                is_secret = status == "11"
+
+                pyotherside.send('requestInput', meta, is_secret)
+
                 self.current_url = url
                 break
                 # Follow redirects

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -270,6 +270,10 @@ class Gemini:
         try:
 
             gemsite = self.get_site(url)
+
+            if gemsite is None:
+                return
+
             gemsite = self.instert_html_links(gemsite, self.get_links(gemsite, url))
             self.cache_page(url, gemsite)
 


### PR DESCRIPTION
This is a pretty small PR, gemini text input is fairly simple. Based on the Gemini spec I have added support for text input on the 10 and 11 status codes. Addresses #16.

10 for basic text input
11 for sensitive text input (passwords and such)

I also noticed in the spec how the response header is formatted and the meta field which can include a prompt for the user, so I added support for that too. I did my testing on gemini://geminispace.info/search because gus.guru was not working while working on this feature. I wasn't able to find a server that would respond with 11 in order to test handling of that response, but theoretically it should work. It would be nice if there was a server that returned all of the different status codes for testing. Anyways.

Let me know what you think, I can make changes!