### PR TITLE
Add Translations

### DIFF
--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -8,14 +8,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gem.aaron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-18 18:21+0000\n"
+"POT-Creation-Date: 2021-08-03 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: en_CA\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: ../qml/Main.qml:127
 msgid "Save Bookmark"
@@ -55,11 +56,11 @@ msgstr ""
 
 #: ../qml/Main.qml:323
 msgid "loadingMessage"
-msgstr ""
+msgstr "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
 
 #: ../qml/Main.qml:336
 msgid "errorMessage"
-msgstr ""
+msgstr "uhm... seems like this site does not exist, it might also be bug <br> ¯_( ͡❛ ͜ʖ ͡❛)_/¯"
 
 #: Gem.desktop.in.h:1
 msgid "Gem"

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -8,14 +8,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gem.aaron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-18 18:21+0000\n"
+"POT-Creation-Date: 2021-08-03 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: ../qml/Main.qml:127
 msgid "Save Bookmark"
@@ -55,11 +56,11 @@ msgstr ""
 
 #: ../qml/Main.qml:323
 msgid "loadingMessage"
-msgstr ""
+msgstr "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
 
 #: ../qml/Main.qml:336
 msgid "errorMessage"
-msgstr ""
+msgstr "uhm... seems like this site does not exist, it might also be bug <br> ¯_( ͡❛ ͜ʖ ͡❛)_/¯"
 
 #: Gem.desktop.in.h:1
 msgid "Gem"

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -124,25 +124,25 @@ MainView {
       id: dialog
       Dialog {
         id: dialogue
-        title: "Save Bookmark"
+        title: i18n.tr("Save Bookmark")
         TextField {
           id: bmurl
           text: adress.text
-          placeholderText: "url"
+          placeholderText: i18n.tr("url")
           hasClearButton: true
         }
         TextField {
           id: bmname
           text: ""
-          placeholderText: "Name"
+          placeholderText: i18n.tr("Name")
           hasClearButton: true
         }
         Button {
-          text: "cancel"
+          text: i18n.tr("cancel")
           onClicked: PopupUtils.close(dialogue)
         }
         Button {
-          text: "save"
+          text: i18n.tr("save")
           color: UbuntuColors.orange
           onClicked: {
             forceActiveFocus()
@@ -187,7 +187,7 @@ MainView {
 
       Dialog {
         id: inputDialog
-        title: "Input requested"
+        title: i18n.tr("Input requested")
 
         property bool isSecret: false
 
@@ -205,11 +205,11 @@ MainView {
           onAccepted: submit()
         }
         Button {
-          text: "cancel"
+          text: i18n.tr("cancel")
           onClicked: PopupUtils.close(inputDialog)
         }
         Button {
-          text: "send"
+          text: i18n.tr("send")
           color: UbuntuColors.orange
           onClicked: submit()
         }
@@ -223,7 +223,7 @@ MainView {
       clip: true
       height: parent.height
       hint {
-        text: "Bookmarks"
+        text: i18n.tr("Bookmarks")
       }
       contentComponent: Rectangle {
         clip: true
@@ -244,7 +244,7 @@ MainView {
             leadingActionBar.actions: [
               Action {
                   iconName: "down"
-                  text: "Collapse"
+                  text: i18n.tr("Collapse")
                   onTriggered: bottomEdge.collapse()
               }
             ]
@@ -320,7 +320,7 @@ MainView {
           console.log('module gemini imported');
 
           python.setHandler('loading', function(url) {
-            content.text = "<center>Loading.. Stay calm!</center> <br> <center>(っ⌒‿⌒)っ</center>"
+            content.text = i18n.tr("loadingMessage")
             adress.text = url;
           })
 
@@ -330,6 +330,10 @@ MainView {
             if (scrollHeight) {
               flick.contentY = scrollHeight;
             }
+          })
+
+          python.setHandler('onLoadError', function() {
+            content.text = i18n.tr("errorMessage")
           })
 
           python.setHandler('externalUrl', function(url) {

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -316,7 +316,7 @@ class Gemini:
                 pyotherside.send('onLoad', gophsite, scroll_height)
             except Exception as e:
                 print("Error:", e)
-                pyotherside.send('onLoad', "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯")
+                pyotherside.send('onLoadError')
             return;
 
 
@@ -333,7 +333,7 @@ class Gemini:
             pyotherside.send('onLoad', gemsite, scroll_height)
         except Exception as e:
             print("Error:", e)
-            pyotherside.send('onLoad', "uhm... seems like this site does not exist, it might also be bug <br> ¯\_( ͡❛ ͜ʖ ͡❛)_/¯")
+            pyotherside.send('onLoadError')
 
         return;
 


### PR DESCRIPTION
This is to address #21
I have never added translations to a ubuntu touch app before, so I might be doing it wrong. I replaced all of the text with `i18n.tr()` calls. The most complicated bit was the loading and error messages. The error message was inside the python file so I added a `onLoadError` event to show a translatable message in QML. I didn't like how the loading and error messages would show up as the message id in the translation file, so I just used `loadingMessage` and `errorMessage` as the message id and added en_US and en_CA (for me) and added the error messages. There might be a way to do a default value, but there isn't much documentation that I could find.

I'm open to input and I know it will be a while before we can merge this!